### PR TITLE
Fix initscript PRIVKEY_PATH

### DIFF
--- a/soledad_server/changes/fix_privkey
+++ b/soledad_server/changes/fix_privkey
@@ -1,0 +1,2 @@
+Fix double specified /etc/leap/soledad-server.pem in initscript by pointing
+the PRIVKEY_PATH to /etc/leap/soledad-server.key. Fixes #3174.

--- a/soledad_server/pkg/soledad
+++ b/soledad_server/pkg/soledad
@@ -17,7 +17,7 @@ LOGFILE=/var/log/soledad.log
 HTTPS_PORT=2424
 PLAIN_PORT=65534
 CERT_PATH=/etc/leap/soledad-server.pem
-PRIVKEY_PATH=/etc/leap/soledad-server.pem
+PRIVKEY_PATH=/etc/leap/soledad-server.key
 TWISTD_PATH=/usr/bin/twistd
 HOME=/var/lib/soledad/
 


### PR DESCRIPTION
This should fix issue #3174 - setting the private key file to a different file
