### PR TITLE
Remove the hard-dep on six

### DIFF
--- a/common/pkg/requirements-testing.pip
+++ b/common/pkg/requirements-testing.pip
@@ -4,3 +4,7 @@ testscenarios
 leap.common
 leap.soledad.server
 leap.soledad.client
+
+# Under quarantine...
+# I've been able to run all tests with six==1.3 -- kali
+# six==1.1.0  # some tests are incompatible with newer versions of six.

--- a/common/pkg/requirements.pip
+++ b/common/pkg/requirements.pip
@@ -1,6 +1,5 @@
 simplejson
 u1db
-six==1.1.0  # some tests are incompatible with newer versions of six.
 
 #this is not strictly needed by us, but we need it
 #until u1db adds it to its release as a dep.


### PR DESCRIPTION
It looks like it is no longer needed, but leaving it commented
until we do some more tests.
