### PR TITLE
Support use of non-ascii passwords.

### DIFF
--- a/client/changes/bug-4001_support-non-ascii-passwords
+++ b/client/changes/bug-4001_support-non-ascii-passwords
@@ -1,0 +1,1 @@
+  o Support non-ascii passwords. Closes #4001.

--- a/client/src/leap/soledad/client/__init__.py
+++ b/client/src/leap/soledad/client/__init__.py
@@ -1118,7 +1118,7 @@ class Soledad(object):
         doc='The secret used for symmetric encryption.')
 
     def _get_passphrase(self):
-        return self._passphrase
+        return self._passphrase.decode("UTF-8")
 
     passphrase = property(
         _get_passphrase,


### PR DESCRIPTION
[Closes #4001]

This needs to be merged along with keymanager and leap_mail pullreqs, I'll post the links below.
