### PR TITLE
Passphrase is already an unicode object.

### DIFF
--- a/client/src/leap/soledad/client/__init__.py
+++ b/client/src/leap/soledad/client/__init__.py
@@ -1190,7 +1190,7 @@ class Soledad(object):
         doc='The secret used for symmetric encryption.')
 
     def _get_passphrase(self):
-        return self._passphrase.decode("UTF-8")
+        return self._passphrase
 
     passphrase = property(
         _get_passphrase,


### PR DESCRIPTION
As we enforce to have the passphrase as an unicode object, we no longer
need this conversion.

[Related to bug #4330]
