### PR TITLE
open db in autocommit mode

### DIFF
--- a/client/changes/bug_open-db-in-autocommit-mode
+++ b/client/changes/bug_open-db-in-autocommit-mode
@@ -1,0 +1,2 @@
+  o Open db in autocommit mode, to avoid nested transactions problems.
+    Closes: #4400


### PR DESCRIPTION
This fixes a problem surfaced with the current 0.3.6 debian package, which uses debian libsqlcipher0.
After this is merged, I will cherry-pick this in the debian branch and rebuild the packages.
