### PR TITLE
bump requirements to latest leap.common

### DIFF
--- a/client/pkg/requirements.pip
+++ b/client/pkg/requirements.pip
@@ -8,7 +8,7 @@ pycryptopp
 # leap deps
 #
 
-leap.soledad.common>=0.3.0
+leap.soledad.common>=0.3.8
 
 #
 # XXX things to fix yet:


### PR DESCRIPTION
this is needed due to the introduction of new events.
