### PR TITLE
Include ddocs in sdist (#5896).

### DIFF
--- a/common/MANIFEST.in
+++ b/common/MANIFEST.in
@@ -2,3 +2,4 @@ include pkg/*
 include versioneer.py
 include LICENSE
 include CHANGELOG
+recursive-include src/leap/soledad/common/ddocs *

--- a/common/changes/bug_5896_include-ddocs-source-in-sdist
+++ b/common/changes/bug_5896_include-ddocs-source-in-sdist
@@ -1,0 +1,2 @@
+  o Include couch design docs source files in source distribution and only
+    compile ddocs.py when building the package (#5896).

--- a/common/setup.py
+++ b/common/setup.py
@@ -229,23 +229,6 @@ class cmd_develop(_cmd_develop):
 
 
 # versioneer powered
-old_cmd_sdist = cmdclass["sdist"]
-
-
-class cmd_sdist(old_cmd_sdist):
-    """
-    Generate 'src/leap/soledad/common/ddocs.py' which contains couch design
-    documents scripts.
-    """
-    def run(self):
-        old_cmd_sdist.run(self)
-
-    def make_release_tree(self, base_dir, files):
-        old_cmd_sdist.make_release_tree(self, base_dir, files)
-        build_ddocs_py(basedir=base_dir)
-
-
-# versioneer powered
 old_cmd_build = cmdclass["build"]
 
 
@@ -257,7 +240,6 @@ class cmd_build(old_cmd_build):
 
 cmdclass["freeze_debianver"] = freeze_debianver
 cmdclass["build"] = cmd_build
-cmdclass["sdist"] = cmd_sdist
 cmdclass["develop"] = cmd_develop
 
 


### PR DESCRIPTION
Soledad common package has a problem where it could not find the `ddocs/` directory when building the package for installation from source.

A proposed solution modified `setup.py` to only compiled the docs when the `ddocs/` dir is available and the `ddocs.py` file is not (https://github.com/leapcode/soledad/pull/167). That solution works to avoid the error when installing the package from source but doesn't address the question of exactly when the `ddocs.py` document should be compiled and exactly when the `ddocs/` dir should cease to exist.

It seems that the a better approach is to
1. include the `ddocs/` directory in the source distribution (because when people download the source distribution they want to actually read the contents of the `.js` files that generate `ddocs.py`, and
2. do not compile `ddocs.py` when building the source dist, but rather only compile it when building the egg and when installing in develop env.
