### PR TITLE
force tls in soledad client. Partially fixes #6437

### DIFF
--- a/client/changes/bug_6437_use_tls
+++ b/client/changes/bug_6437_use_tls
@@ -1,0 +1,1 @@
+  o Use TLS v1 in soledad client. Fixes partially #6437

--- a/client/src/leap/soledad/client/__init__.py
+++ b/client/src/leap/soledad/client/__init__.py
@@ -811,7 +811,8 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
 
         self.sock = ssl.wrap_socket(sock,
                                     ca_certs=SOLEDAD_CERT,
-                                    cert_reqs=ssl.CERT_REQUIRED)
+                                    cert_reqs=ssl.CERT_REQUIRED,
+                                    ssl_version=ssl.PROTOCOL_TLSv1)
         match_hostname(self.sock.getpeercert(), self.host)
 
 


### PR DESCRIPTION
Force tls 1.2 in client. 
By default, this was using SSLv23 (We ARE NOT using the harcoded SSLv3 that's in u1db wrapper, which has been patched in debian).

I think we could cherry pick this (and probably the related server side fix) into a 0.6.x release branch, and tag a 0.6.1 version on time for platform release.

@andrejb whatchathink?
