### PR TITLE
Use SSL negotiation.

### DIFF
--- a/client/src/leap/soledad/client/__init__.py
+++ b/client/src/leap/soledad/client/__init__.py
@@ -809,10 +809,23 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
             self.sock = sock
             self._tunnel()
 
-        self.sock = ssl.wrap_socket(sock,
-                                    ca_certs=SOLEDAD_CERT,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ssl_version=ssl.PROTOCOL_TLSv1)
+        # negotiate the best availabe version...
+        ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+
+        # but if possible, we want to disable bad ones
+        # needs python 2.7.9+
+        try:
+            ctx.options |= ssl.OP_NO_SSLv2
+            ctx.options |= ssl.OP_NO_SSLv3
+        except AttributeError:
+            pass
+
+        ctx.load_cert_chain(certfile=SOLEDAD_CERT)
+        ctx.verify_mode = ssl.CERT_REQUIRED
+
+        self.sock = ctx.wrap_socket(
+            sock, server_side=True, server_hostname=self.host)
+
         match_hostname(self.sock.getpeercert(), self.host)
 
 

--- a/server/pkg/soledad
+++ b/server/pkg/soledad
@@ -19,7 +19,7 @@ CERT_PATH=/etc/leap/soledad-server.pem
 PRIVKEY_PATH=/etc/leap/soledad-server.key
 TWISTD_PATH=/usr/bin/twistd
 HOME=/var/lib/soledad/
-SSL_METHOD=TLSv1_METHOD
+SSL_METHOD=SSLv23_METHOD
 USER=soledad
 GROUP=soledad
 


### PR DESCRIPTION
Although the API can be misleading, PROTOCOL_SSLv23 selects the highest
protocol version that both the client and server support. Despite the
name, this option can select “TLS” protocols as well as “SSL”.

In this way, we can use TLSv1.2 (PROTOCOL_TLSv1 will _only_ give us TLS
v1.0)

In the client side, we try to disable SSLv2 and SSLv3 options
explicitely.

The python version in wheezy does not offer PROTOCOL_TLSv1_2 nor
OP_NO_SSLv2 or OP_NO_SSLv3 (It's new in 2.7.9)
