### PR TITLE
Fix incorrect ssl context setup

### DIFF
--- a/client/src/leap/soledad/client/__init__.py
+++ b/client/src/leap/soledad/client/__init__.py
@@ -819,10 +819,9 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
             ctx.options |= ssl.OP_NO_SSLv2
             ctx.options |= ssl.OP_NO_SSLv3
 
-            ctx.load_cert_chain(certfile=SOLEDAD_CERT)
+            ctx.load_verify_locations(cafile=SOLEDAD_CERT)
             ctx.verify_mode = ssl.CERT_REQUIRED
-            self.sock = ctx.wrap_socket(
-                sock, server_side=True, server_hostname=self.host)
+            self.sock = ctx.wrap_socket(sock)
 
         except AttributeError:
             self.sock = ssl.wrap_socket(


### PR DESCRIPTION
The changes introduced in aafa79c0f5 having to do with the cert
verification are incorrect, regarding the use of the newest ssl context
api introduced in python 2.7.9. There the use of the server setup was
taken, instead of the correct client options.

I hereby apologize for the insuficient testing on that fix. It happens
that I wrongly tested in an evironment that did the fallback to
pre-2.7.9 interpreter.
