### PR TITLE
Bug/6797 add dependency on twisted (and fix/improve others)

### DIFF
--- a/client/changes/bug_6797_add-dependency-on-twisted
+++ b/client/changes/bug_6797_add-dependency-on-twisted
@@ -1,0 +1,1 @@
+  o Add dependency on Twisted. Closes #6797.

--- a/client/pkg/requirements.pip
+++ b/client/pkg/requirements.pip
@@ -5,6 +5,7 @@ scrypt
 pycryptopp
 cchardet
 zope.proxy
+twisted
 
 #
 # leap deps

--- a/client/pkg/requirements.pip
+++ b/client/pkg/requirements.pip
@@ -7,16 +7,11 @@ cchardet
 zope.proxy
 twisted
 
-#
-# leap deps
-#
-
+# leap deps -- bump me!
+leap.common
 leap.soledad.common>=0.6.0
 
-#
-# XXX things to fix yet:
-#
-
-# this is not strictly needed by us, but we need it
-# until u1db adds it to its release as a dep.
+# XXX -- fix me!
+# oauth is not strictly needed by us, but we need it until u1db adds it to its
+# release as a dep.
 oauth

--- a/client/src/leap/soledad/client/events.py
+++ b/client/src/leap/soledad/client/events.py
@@ -21,38 +21,35 @@ Signaling functions.
 """
 
 
-SOLEDAD_CREATING_KEYS = 'Creating keys...'
-SOLEDAD_DONE_CREATING_KEYS = 'Done creating keys.'
-SOLEDAD_DOWNLOADING_KEYS = 'Downloading keys...'
-SOLEDAD_DONE_DOWNLOADING_KEYS = 'Done downloading keys.'
-SOLEDAD_UPLOADING_KEYS = 'Uploading keys...'
-SOLEDAD_DONE_UPLOADING_KEYS = 'Done uploading keys.'
-SOLEDAD_NEW_DATA_TO_SYNC = 'New data available.'
-SOLEDAD_DONE_DATA_SYNC = 'Done data sync.'
-SOLEDAD_SYNC_SEND_STATUS = 'Sync: sent one document.'
-SOLEDAD_SYNC_RECEIVE_STATUS = 'Sync: received one document.'
+from leap.common import events
+from leap.common.events import signal
 
-# we want to use leap.common.events to emits signals, if it is available.
-try:
-    from leap.common import events
-    from leap.common.events import signal
-    SOLEDAD_CREATING_KEYS = events.proto.SOLEDAD_CREATING_KEYS
-    SOLEDAD_DONE_CREATING_KEYS = events.proto.SOLEDAD_DONE_CREATING_KEYS
-    SOLEDAD_DOWNLOADING_KEYS = events.proto.SOLEDAD_DOWNLOADING_KEYS
-    SOLEDAD_DONE_DOWNLOADING_KEYS = \
-        events.proto.SOLEDAD_DONE_DOWNLOADING_KEYS
-    SOLEDAD_UPLOADING_KEYS = events.proto.SOLEDAD_UPLOADING_KEYS
-    SOLEDAD_DONE_UPLOADING_KEYS = \
-        events.proto.SOLEDAD_DONE_UPLOADING_KEYS
-    SOLEDAD_NEW_DATA_TO_SYNC = events.proto.SOLEDAD_NEW_DATA_TO_SYNC
-    SOLEDAD_DONE_DATA_SYNC = events.proto.SOLEDAD_DONE_DATA_SYNC
-    SOLEDAD_SYNC_SEND_STATUS = events.proto.SOLEDAD_SYNC_SEND_STATUS
-    SOLEDAD_SYNC_RECEIVE_STATUS = events.proto.SOLEDAD_SYNC_RECEIVE_STATUS
 
-except ImportError:
-    # we define a fake signaling function and fake signal constants that will
-    # allow for logging signaling attempts in case leap.common.events is not
-    # available.
+SOLEDAD_CREATING_KEYS = events.proto.SOLEDAD_CREATING_KEYS
+SOLEDAD_DONE_CREATING_KEYS = events.proto.SOLEDAD_DONE_CREATING_KEYS
+SOLEDAD_DOWNLOADING_KEYS = events.proto.SOLEDAD_DOWNLOADING_KEYS
+SOLEDAD_DONE_DOWNLOADING_KEYS = \
+    events.proto.SOLEDAD_DONE_DOWNLOADING_KEYS
+SOLEDAD_UPLOADING_KEYS = events.proto.SOLEDAD_UPLOADING_KEYS
+SOLEDAD_DONE_UPLOADING_KEYS = \
+    events.proto.SOLEDAD_DONE_UPLOADING_KEYS
+SOLEDAD_NEW_DATA_TO_SYNC = events.proto.SOLEDAD_NEW_DATA_TO_SYNC
+SOLEDAD_DONE_DATA_SYNC = events.proto.SOLEDAD_DONE_DATA_SYNC
+SOLEDAD_SYNC_SEND_STATUS = events.proto.SOLEDAD_SYNC_SEND_STATUS
+SOLEDAD_SYNC_RECEIVE_STATUS = events.proto.SOLEDAD_SYNC_RECEIVE_STATUS
 
-    def signal(signal, content=""):
-        logger.info("Would signal: %s - %s." % (str(signal), content))
+
+__all__ = [
+    "events",
+    "signal",
+    "SOLEDAD_CREATING_KEYS",
+    "SOLEDAD_DONE_CREATING_KEYS",
+    "SOLEDAD_DOWNLOADING_KEYS",
+    "SOLEDAD_DONE_DOWNLOADING_KEYS",
+    "SOLEDAD_UPLOADING_KEYS",
+    "SOLEDAD_DONE_UPLOADING_KEYS",
+    "SOLEDAD_NEW_DATA_TO_SYNC",
+    "SOLEDAD_DONE_DATA_SYNC",
+    "SOLEDAD_SYNC_SEND_STATUS",
+    "SOLEDAD_SYNC_RECEIVE_STATUS",
+]

--- a/common/pkg/requirements.pip
+++ b/common/pkg/requirements.pip
@@ -1,7 +1,10 @@
 simplejson
 u1db
 
-#this is not strictly needed by us, but we need it
-#until u1db adds it to its release as a dep.
-oauth
+# leap deps -- bump me!
+leap.common
 
+# XXX -- fix me!
+# oauth is not strictly needed by us, but we need it until u1db adds it to its
+# release as a dep.
+oauth

--- a/common/setup.py
+++ b/common/setup.py
@@ -270,7 +270,7 @@ setup(
     ),
     classifiers=trove_classifiers,
     namespace_packages=["leap", "leap.soledad"],
-    packages=find_packages('src', exclude=['leap.soledad.common.tests']),
+    packages=find_packages('src', exclude=['*.tests', '*.tests.*']),
     package_dir={'': 'src'},
     test_suite='leap.soledad.common.tests',
     install_requires=utils.parse_requirements(),

--- a/common/src/leap/soledad/common/__init__.py
+++ b/common/src/leap/soledad/common/__init__.py
@@ -34,45 +34,17 @@ USER_DB_PREFIX = 'user-'
 # Global functions
 #
 
-# we want to use leap.common.check.leap_assert in case it is available,
-# because it also logs in a way other parts of leap can access log messages.
-
-try:
-    from leap.common.check import leap_assert as soledad_assert
-
-except ImportError:
-
-    def soledad_assert(condition, message):
-        """
-        Asserts the condition and displays the message if that's not
-        met.
-
-        @param condition: condition to check
-        @type condition: bool
-        @param message: message to display if the condition isn't met
-        @type message: str
-        """
-        assert condition, message
-
-try:
-    from leap.common.check import leap_assert_type as soledad_assert_type
-
-except ImportError:
-
-    def soledad_assert_type(var, expectedType):
-        """
-        Helper assert check for a variable's expected type
-
-        @param var: variable to check
-        @type var: any
-        @param expectedType: type to check agains
-        @type expectedType: type
-        """
-        soledad_assert(isinstance(var, expectedType),
-                       "Expected type %r instead of %r" %
-                       (expectedType, type(var)))
+from leap.common.check import leap_assert as soledad_assert
+from leap.common.check import leap_assert_type as soledad_assert_type
 
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+__all__ = [
+    "soledad_assert",
+    "soledad_assert_type",
+    "__version__",
+]

--- a/server/changes/bug_6797_add-dependency-on-twisted
+++ b/server/changes/bug_6797_add-dependency-on-twisted
@@ -1,0 +1,1 @@
+  o Add dependency on Twisted. Closes #6797.

--- a/server/pkg/requirements.pip
+++ b/server/pkg/requirements.pip
@@ -9,12 +9,7 @@ twisted
 # leap deps -- bump me!
 leap.soledad.common>=0.6.0
 
-#
-# Things yet to fix:
-#
-
-# oauth is not strictly needed by us, but we need it
-# until u1db adds it to its release as a dep.
-
+# XXX -- fix me!
+# oauth is not strictly needed by us, but we need it until u1db adds it to its
+# release as a dep.
 oauth
-

--- a/server/pkg/requirements.pip
+++ b/server/pkg/requirements.pip
@@ -4,9 +4,7 @@ simplejson
 u1db
 routes
 PyOpenSSL<0.14
-
-# TODO: maybe we just want twisted-web?
-twisted>=12.0.0
+twisted
 
 # leap deps -- bump me!
 leap.soledad.common>=0.6.0


### PR DESCRIPTION
This pull request handles many dependency issues:

* twisted
* oauth
* leap.common

It also includes a fix in common's setup.py to ensure all tests are excluded from installation and as a consequence also from debian package.