### PR TITLE
[fix] turn client side db access script into async

### DIFF
--- a/scripts/db_access/util.py
+++ b/scripts/db_access/util.py
@@ -1,0 +1,1 @@
+../profiling/util.py


### PR DESCRIPTION
With changes in soledad client api to make it async, the supporting scripts
also have to be updated. This commit also adds more functionalities as
exporting incoming mail and public or private keys.