### PR TITLE
[bug] retry the sync insertion loop in case of InvalidGenerationError

### DIFF
--- a/client/src/leap/soledad/client/crypto.py
+++ b/client/src/leap/soledad/client/crypto.py
@@ -28,6 +28,7 @@ import threading
 
 from pycryptopp.cipher.aes import AES
 from pycryptopp.cipher.xsalsa20 import XSalsa20
+from u1db import errors
 from zope.proxy import sameProxiedObjects
 
 from leap.soledad.common import soledad_assert
@@ -1017,6 +1018,9 @@ class SyncDecrypterPool(SyncEncryptDecryptPool):
             doc = SoledadDocument(doc_id, doc_rev, content)
             gen = int(gen)
             insert_fun(doc, gen, trans_id)
+        except errors.InvalidGeneration as exc:
+            # raise it up so we can stop the insert loop
+            raise
         except Exception as exc:
             logger.error("Sync decrypter pool: error while inserting "
                          "decrypted doc into local db.")


### PR DESCRIPTION
If the generation changes while a sync is happening the sync fails with
InvalidGenerationError. This can happen if there is an insertion or
another operation before the sync finishes. The sync was going to an
error loop.

The proposed solution is to retry the sync loop in case of failure. As
collateral effect if the insertion loop has not process all the docs we
retry as well.

Resolves: #6757