### PR TITLE
[fix] remove unneded params to CouchServerState

### DIFF
--- a/common/changes/bug_6833_remove-unneeded-params-from-couch-server-state
+++ b/common/changes/bug_6833_remove-unneeded-params-from-couch-server-state
@@ -1,0 +1,2 @@
+  o Remove unneeded parameters from CouchServerState initialization. Closes
+    #6833.

--- a/common/src/leap/soledad/common/couch.py
+++ b/common/src/leap/soledad/common/couch.py
@@ -1528,20 +1528,14 @@ class CouchServerState(ServerState):
     Inteface of the WSGI server with the CouchDB backend.
     """
 
-    def __init__(self, couch_url, shared_db_name, tokens_db_name):
+    def __init__(self, couch_url):
         """
         Initialize the couch server state.
 
         :param couch_url: The URL for the couch database.
         :type couch_url: str
-        :param shared_db_name: The name of the shared database.
-        :type shared_db_name: str
-        :param tokens_db_name: The name of the tokens database.
-        :type tokens_db_name: str
         """
         self._couch_url = couch_url
-        self._shared_db_name = shared_db_name
-        self._tokens_db_name = tokens_db_name
 
     def open_database(self, dbname):
         """

--- a/server/changes/bug_6833_remove-unneeded-params-from-couch-server-state
+++ b/server/changes/bug_6833_remove-unneeded-params-from-couch-server-state
@@ -1,0 +1,2 @@
+  o Remove unneeded parameters from CouchServerState initialization. Closes
+    #6833.

--- a/server/src/leap/soledad/server/__init__.py
+++ b/server/src/leap/soledad/server/__init__.py
@@ -296,10 +296,7 @@ def load_configuration(file_path):
 
 def application(environ, start_response):
     conf = load_configuration('/etc/leap/soledad-server.conf')
-    state = CouchServerState(
-        conf['couch_url'],
-        SoledadApp.SHARED_DB_NAME,
-        SoledadTokenAuthMiddleware.TOKENS_DB)
+    state = CouchServerState(conf['couch_url'])
     # WSGI application that may be used by `twistd -web`
     application = GzipMiddleware(
         SoledadTokenAuthMiddleware(SoledadApp(state)))


### PR DESCRIPTION
This commit removes some leftover code from a time when Soledad Server used to
check for permissions on certain databases when starting (i.e. shared and
tokens databases). This was later removed as correct permissions enforcement
was relayed to tapicero.

Closes: #6833.