### PR TITLE
[pkg] bump version of server dependency on common

### DIFF
--- a/server/pkg/requirements.pip
+++ b/server/pkg/requirements.pip
@@ -7,7 +7,7 @@ PyOpenSSL<0.14
 twisted
 
 # leap deps -- bump me!
-leap.soledad.common>=0.6.0
+leap.soledad.common>=0.6.5
 
 # XXX -- fix me!
 # oauth is not strictly needed by us, but we need it until u1db adds it to its


### PR DESCRIPTION
soledad-common versions before 0.6.5 do not contain the fix for #6833 and thus
will not work with most recent server. That is why we have to bump this
soledad-server dependency on soledad.common.