### PR TITLE
[pkg] bump client/server dependencies on common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,42 +2,43 @@ Source: soledad
 Section: python
 Priority: optional
 Maintainer: Micah Anderson <micah@debian.org>
-Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.6.6-3), debhelper (>= 9)
-Standards-Version: 3.9.5
+Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.6.6-3),
+ debhelper (>= 9), dh-python
+Standards-Version: 3.9.6
 
 Package: soledad-server
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-configparser, python-couchdb, 
  python-simplejson, python-oauth, python-u1db, python-routes, python-openssl, 
- soledad-common (>= 0.5.0), python-six, python-twisted-web (>= 13.0.0-1~bpo70+1)
+ soledad-common (>= 0.6.5), python-six, python-twisted-web (>= 13.0.0-1~bpo70+1)
 Description: Synchronization of locally encrypted data among devices.
  Soledad is the part of LEAP that allows application data to be securely 
  shared among devices. It provides, to other parts of the LEAP client, an 
  API for data storage and sync.
- . 
+ .
  This package contains the server components.
 
 Package: soledad-common
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, python-simplejson, python-oauth, python-u1db, 
- python-six
+Depends: ${misc:Depends}, ${python:Depends}, python-simplejson, python-oauth,
+ python-u1db, python-six
 Description: Synchronization of locally encrypted data among devices.
  Soledad is the part of LEAP that allows application data to be securely 
  shared among devices. It provides, to other parts of the LEAP client, an 
  API for data storage and sync.
- . 
+ .
  This package contains the common soledad libraries. For the server, see the
  soledad-server package
 
 Package: soledad-client
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-sqlcipher (>= 2.6.3.1),
- python-simplejson, python-oauth, python-u1db, python-scrypt, 
- python-dirspec, python-pycryptopp (>= 0.6.0.20120313-1~), soledad-common,
+ python-simplejson, python-oauth, python-u1db, python-scrypt, python-dirspec,
+ python-pycryptopp (>= 0.6.0.20120313-1~), soledad-common (>= 0.6.0),
  python-chardet, python-twisted-core
 Description: Synchronization of locally encrypted data among devices.
  Soledad is the part of LEAP that allows application data to be securely 
  shared among devices. It provides, to other parts of the LEAP client, an 
  API for data storage and sync.
- . 
+ .
  This package contains the soledad client.


### PR DESCRIPTION
This commit also does the following in the debian/control file:

  * Add dh-python package build dependency.

  * Remove trailing whitespace after new-line dot markers on package
    descriptions. This was causing a lintian warning saying
    description-contains-invalid-control-statement.