### PR TITLE
[refactor] use a deferred to signal when SyncDecriptionPool has finished

### DIFF
--- a/client/changes/feat-refactor_decr_pool
+++ b/client/changes/feat-refactor_decr_pool
@@ -1,0 +1,1 @@
+- Refactor decription pool and http target to use a deferred instead of a waiting loop.


### PR DESCRIPTION
It makes the code simpler and clearer to use a deferred instead of
having to pull on 'has_finished'.

- Related: #7234