### PR TITLE
[pkg] separate leap requirements

### DIFF
--- a/client/pkg/requirements-leap.pip
+++ b/client/pkg/requirements-leap.pip
@@ -1,0 +1,2 @@
+leap.common>=0.4.1
+leap.soledad.common>=0.6.5

--- a/client/pkg/requirements.pip
+++ b/client/pkg/requirements.pip
@@ -7,10 +7,6 @@ cchardet
 zope.proxy
 twisted
 
-# leap deps -- bump me!
-leap.common>=0.4.1
-leap.soledad.common>=0.6.5
-
 # XXX -- fix me!
 # oauth is not strictly needed by us, but we need it until u1db adds it to its
 # release as a dep.

--- a/client/pkg/utils.py
+++ b/client/pkg/utils.py
@@ -14,14 +14,28 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """
 Utils to help in the setup process
 """
-
 import os
 import re
 import sys
+
+
+def is_develop_mode():
+    """
+    Returns True if we're calling the setup script using the argument for
+    setuptools development mode.
+
+    This avoids messing up with dependency pinning and order, the
+    responsibility of installing the leap dependencies is left to the
+    developer.
+    """
+    args = sys.argv
+    devflags = "setup.py", "develop"
+    if (args[0], args[1]) == devflags:
+        return True
+    return False
 
 
 def get_reqs_from_files(reqfiles):
@@ -58,9 +72,9 @@ def parse_requirements(reqfiles=['requirements.txt',
         if re.match(r'\s*-e\s+', line):
             pass
             # do not try to do anything with externals on vcs
-            #requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
-                                #line))
-        # http://foo.bar/baz/foobar/zipball/master#egg=foobar
+            # requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
+            # line))
+            # http://foo.bar/baz/foobar/zipball/master#egg=foobar
         elif re.match(r'\s*https?:', line):
             requirements.append(re.sub(r'\s*https?:.*#egg=(.*)$', r'\1',
                                 line))

--- a/client/setup.py
+++ b/client/setup.py
@@ -106,7 +106,24 @@ def get_versions(default={}, verbose=False):
 
 cmdclass["freeze_debianver"] = freeze_debianver
 
+
 # XXX add ref to docs
+
+requirements = utils.parse_requirements()
+
+if utils.is_develop_mode():
+    print
+    print ("[WARNING] Skipping leap-specific dependencies "
+           "because development mode is detected.")
+    print ("[WARNING] You can install "
+           "the latest published versions with "
+           "'pip install -r pkg/requirements-leap.pip'")
+    print ("[WARNING] Or you can instead do 'python setup.py develop' "
+           "from the parent folder of each one of them.")
+    print
+else:
+    requirements += utils.parse_requirements(
+        reqfiles=["pkg/requirements-leap.pip"])
 
 setup(
     name='leap.soledad.client',
@@ -130,6 +147,6 @@ setup(
     namespace_packages=["leap", "leap.soledad"],
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=utils.parse_requirements(),
+    install_requires=requirements,
     extras_require={'signaling': ['leap.common>=0.3.0']},
 )

--- a/common/pkg/requirements-leap.pip
+++ b/common/pkg/requirements-leap.pip
@@ -1,0 +1,1 @@
+leap.common>=0.4.0

--- a/common/pkg/requirements.pip
+++ b/common/pkg/requirements.pip
@@ -1,9 +1,6 @@
 simplejson
 u1db
 
-# leap deps -- bump me!
-leap.common>=0.4.0
-
 # XXX -- fix me!
 # oauth is not strictly needed by us, but we need it until u1db adds it to its
 # release as a dep.

--- a/common/pkg/utils.py
+++ b/common/pkg/utils.py
@@ -14,20 +14,34 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """
 Utils to help in the setup process
 """
-
 import os
 import re
 import sys
 
 
+def is_develop_mode():
+    """
+    Returns True if we're calling the setup script using the argument for
+    setuptools development mode.
+
+    This avoids messing up with dependency pinning and order, the
+    responsibility of installing the leap dependencies is left to the
+    developer.
+    """
+    args = sys.argv
+    devflags = "setup.py", "develop"
+    if (args[0], args[1]) == devflags:
+        return True
+    return False
+
+
 def get_reqs_from_files(reqfiles):
     """
     Returns the contents of the top requirement file listed as a
-    string list with the lines
+    string list with the lines.
 
     @param reqfiles: requirement files to parse
     @type reqfiles: list of str
@@ -42,6 +56,9 @@ def parse_requirements(reqfiles=['requirements.txt',
                                  'pkg/requirements.pip']):
     """
     Parses the requirement files provided.
+
+    The passed reqfiles list is a list of possible locations to try, the
+    function will return the contents of the first path found.
 
     Checks the value of LEAP_VENV_SKIP_PYSIDE to see if it should
     return PySide as a dep or not. Don't set, or set to 0 if you want
@@ -58,9 +75,9 @@ def parse_requirements(reqfiles=['requirements.txt',
         if re.match(r'\s*-e\s+', line):
             pass
             # do not try to do anything with externals on vcs
-            #requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
-                                #line))
-        # http://foo.bar/baz/foobar/zipball/master#egg=foobar
+            # requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
+            # line))
+            # http://foo.bar/baz/foobar/zipball/master#egg=foobar
         elif re.match(r'\s*https?:', line):
             requirements.append(re.sub(r'\s*https?:.*#egg=(.*)$', r'\1',
                                 line))

--- a/common/setup.py
+++ b/common/setup.py
@@ -250,6 +250,22 @@ cmdclass["develop"] = cmd_develop
 
 # XXX add ref to docs
 
+requirements = utils.parse_requirements()
+
+if utils.is_develop_mode():
+    print
+    print ("[WARNING] Skipping leap-specific dependencies "
+           "because development mode is detected.")
+    print ("[WARNING] You can install "
+           "the latest published versions with "
+           "'pip install -r pkg/requirements-leap.pip'")
+    print ("[WARNING] Or you can instead do 'python setup.py develop' "
+           "from the parent folder of each one of them.")
+    print
+else:
+    requirements += utils.parse_requirements(
+        reqfiles=["pkg/requirements-leap.pip"])
+
 setup(
     name='leap.soledad.common',
     version=VERSION,
@@ -273,7 +289,7 @@ setup(
     packages=find_packages('src', exclude=['*.tests', '*.tests.*']),
     package_dir={'': 'src'},
     test_suite='leap.soledad.common.tests',
-    install_requires=utils.parse_requirements(),
+    install_requires=requirements,
     tests_require=utils.parse_requirements(
         reqfiles=['pkg/requirements-testing.pip']),
     extras_require={

--- a/server/pkg/requirements-leap.pip
+++ b/server/pkg/requirements-leap.pip
@@ -1,0 +1,1 @@
+leap.soledad.common>=0.6.5

--- a/server/pkg/requirements.pip
+++ b/server/pkg/requirements.pip
@@ -6,9 +6,6 @@ routes
 PyOpenSSL
 twisted
 
-# leap deps -- bump me!
-leap.soledad.common>=0.6.5
-
 # XXX -- fix me!
 # oauth is not strictly needed by us, but we need it until u1db adds it to its
 # release as a dep.

--- a/server/pkg/utils.py
+++ b/server/pkg/utils.py
@@ -14,20 +14,34 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """
 Utils to help in the setup process
 """
-
 import os
 import re
 import sys
 
 
+def is_develop_mode():
+    """
+    Returns True if we're calling the setup script using the argument for
+    setuptools development mode.
+
+    This avoids messing up with dependency pinning and order, the
+    responsibility of installing the leap dependencies is left to the
+    developer.
+    """
+    args = sys.argv
+    devflags = "setup.py", "develop"
+    if (args[0], args[1]) == devflags:
+        return True
+    return False
+
+
 def get_reqs_from_files(reqfiles):
     """
     Returns the contents of the top requirement file listed as a
-    string list with the lines
+    string list with the lines.
 
     @param reqfiles: requirement files to parse
     @type reqfiles: list of str
@@ -42,6 +56,9 @@ def parse_requirements(reqfiles=['requirements.txt',
                                  'pkg/requirements.pip']):
     """
     Parses the requirement files provided.
+
+    The passed reqfiles list is a list of possible locations to try, the
+    function will return the contents of the first path found.
 
     Checks the value of LEAP_VENV_SKIP_PYSIDE to see if it should
     return PySide as a dep or not. Don't set, or set to 0 if you want
@@ -58,9 +75,9 @@ def parse_requirements(reqfiles=['requirements.txt',
         if re.match(r'\s*-e\s+', line):
             pass
             # do not try to do anything with externals on vcs
-            #requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
-                                #line))
-        # http://foo.bar/baz/foobar/zipball/master#egg=foobar
+            # requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
+            # line))
+            # http://foo.bar/baz/foobar/zipball/master#egg=foobar
         elif re.match(r'\s*https?:', line):
             requirements.append(re.sub(r'\s*https?:.*#egg=(.*)$', r'\1',
                                 line))

--- a/server/setup.py
+++ b/server/setup.py
@@ -116,6 +116,22 @@ cmdclass["freeze_debianver"] = freeze_debianver
 
 # XXX add ref to docs
 
+requirements = utils.parse_requirements()
+
+if utils.is_develop_mode():
+    print
+    print ("[WARNING] Skipping leap-specific dependencies "
+           "because development mode is detected.")
+    print ("[WARNING] You can install "
+           "the latest published versions with "
+           "'pip install -r pkg/requirements-leap.pip'")
+    print ("[WARNING] Or you can instead do 'python setup.py develop' "
+           "from the parent folder of each one of them.")
+    print
+else:
+    requirements += utils.parse_requirements(
+        reqfiles=["pkg/requirements-leap.pip"])
+
 setup(
     name='leap.soledad.server',
     version=VERSION,
@@ -138,6 +154,6 @@ setup(
     namespace_packages=["leap", "leap.soledad"],
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=utils.parse_requirements(),
+    install_requires=requirements,
     data_files=data_files
 )


### PR DESCRIPTION
this is part of a process to make the setup of the development mode less
troublesome. from now on, setting up a virtualenv in pure development
mode will be as easy as telling pip to just install the external dependencies::

  pip install -r pkg/requirements.pip

and traversing all the leap repos for the needed leap dependencies doing::

  python setup.py develop

- Related: #7288