### PR TITLE
Soledad tests are running again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ MANIFEST
 *.log
 *.*~
 *.csv
+.eggs
+_trial_temp
+.DS_Store

--- a/client/pkg/requirements-latest.pip
+++ b/client/pkg/requirements-latest.pip
@@ -3,6 +3,6 @@
 --allow-external u1db  --allow-unverified u1db
 --allow-external dirspec  --allow-unverified dirspec
 
--e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'
 -e '../common'
 -e .

--- a/client/pkg/requirements-latest.pip
+++ b/client/pkg/requirements-latest.pip
@@ -1,0 +1,8 @@
+--index-url https://pypi.python.org/simple/
+
+--allow-external u1db  --allow-unverified u1db
+--allow-external dirspec  --allow-unverified dirspec
+
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e '../common'
+-e .

--- a/client/src/leap/soledad/client/api.py
+++ b/client/src/leap/soledad/client/api.py
@@ -213,8 +213,7 @@ class Soledad(object):
         soledad_assert_type(self._passphrase, unicode)
 
         def initialize(attr, val):
-            return (getattr(self, attr, None) is None
-                    and setattr(self, attr, val))
+            return (getattr(self, attr, None) is None and setattr(self, attr, val))
 
         initialize("_secrets_path", os.path.join(
             self.default_prefix, self.secrets_file_name))

--- a/common/pkg/requirements-latest.pip
+++ b/common/pkg/requirements-latest.pip
@@ -1,0 +1,6 @@
+--index-url https://pypi.python.org/simple/
+
+--allow-external u1db  --allow-unverified u1db
+--allow-external dirspec  --allow-unverified dirspec
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e .

--- a/common/pkg/requirements-latest.pip
+++ b/common/pkg/requirements-latest.pip
@@ -2,5 +2,5 @@
 
 --allow-external u1db  --allow-unverified u1db
 --allow-external dirspec  --allow-unverified dirspec
--e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'
 -e .

--- a/common/src/leap/soledad/common/tests/util.py
+++ b/common/src/leap/soledad/common/tests/util.py
@@ -43,7 +43,7 @@ from u1db.remote import http_database
 from twisted.trial import unittest
 
 from leap.common.files import mkdir_p
-from leap.common.events.flags import set_events_enabled
+from leap.common.testing.basetest import BaseLeapTest
 
 from leap.soledad.common import soledad_assert
 from leap.soledad.common.document import SoledadDocument
@@ -185,7 +185,7 @@ def token_soledad_sync_target(test, path):
     return st
 
 
-class BaseSoledadTest(unittest.TestCase, MockedSharedDBTest):
+class BaseSoledadTest(BaseLeapTest, MockedSharedDBTest):
     """
     Instantiates Soledad for usage in tests.
     """
@@ -195,8 +195,6 @@ class BaseSoledadTest(unittest.TestCase, MockedSharedDBTest):
         # The following snippet comes from BaseLeapTest.setUpClass, but we
         # repeat it here because twisted.trial does not work with
         # setUpClass/tearDownClass.
-
-        set_events_enabled(False)
 
         self.old_path = os.environ['PATH']
         self.old_home = os.environ['HOME']

--- a/common/src/leap/soledad/common/tests/util.py
+++ b/common/src/leap/soledad/common/tests/util.py
@@ -43,6 +43,7 @@ from u1db.remote import http_database
 from twisted.trial import unittest
 
 from leap.common.files import mkdir_p
+from leap.common.events.flags import set_events_enabled
 
 from leap.soledad.common import soledad_assert
 from leap.soledad.common.document import SoledadDocument
@@ -194,6 +195,9 @@ class BaseSoledadTest(unittest.TestCase, MockedSharedDBTest):
         # The following snippet comes from BaseLeapTest.setUpClass, but we
         # repeat it here because twisted.trial does not work with
         # setUpClass/tearDownClass.
+
+        set_events_enabled(False)
+
         self.old_path = os.environ['PATH']
         self.old_home = os.environ['HOME']
         self.tempdir = tempfile.mkdtemp(prefix="leap_tests-")

--- a/server/pkg/requirements-latest.pip
+++ b/server/pkg/requirements-latest.pip
@@ -3,6 +3,6 @@
 --allow-external u1db  --allow-unverified u1db
 --allow-external dirspec  --allow-unverified dirspec
 
--e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'
 -e '../common'
 -e .

--- a/server/pkg/requirements-latest.pip
+++ b/server/pkg/requirements-latest.pip
@@ -1,0 +1,8 @@
+--index-url https://pypi.python.org/simple/
+
+--allow-external u1db  --allow-unverified u1db
+--allow-external dirspec  --allow-unverified dirspec
+
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git#egg=leap.common'
+-e '../common'
+-e .


### PR DESCRIPTION
The changes include:

- Tests are now running again after the change to zmq, the soledad tests would not run because the zmq_init would fail with certificate error. I disabled events for the soledad tests so we won't have that problem anymore.
You can take a look here: https://snap-ci.com/pixelated-project/soledad/branch/develop/logs/defaultPipeline/22/Tests?back_to=build_history

- Also added some leftovers files from the tests to the gitignore

- Created a requirements-latest.pip to be able to run soledad from head without depending on pypi or specific versions of leap libraries