### PR TITLE
[bug] Soledad._crypto has to be initialized earlier

### DIFF
--- a/client/src/leap/soledad/client/api.py
+++ b/client/src/leap/soledad/client/api.py
@@ -196,9 +196,9 @@ class Soledad(object):
         # The following can raise BootstrapSequenceError, that will be
         # propagated upwards.
         self._init_secrets()
-        self._init_u1db_sqlcipher_backend()
 
         self._crypto = SoledadCrypto(self._secrets.remote_storage_secret)
+        self._init_u1db_sqlcipher_backend()
 
         if syncable:
             self._init_u1db_syncer()


### PR DESCRIPTION
before sqlcipher backend, or the attribute is not found.

this is a leftover of the recent refactor