### PR TITLE
map the leap.common package to the correct debian package

### DIFF
--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -7,3 +7,4 @@ configparser python-configparser
 leap.soledad.common soledad-common
 leap.soledad.server soledad-server
 leap.soledad.client soledad-client
+leap.common python-leap-common


### PR DESCRIPTION
dh_python guesses that leap.common is provided by the debian
package 'python-leap.common' but it is in 'python-leap-common'