### PR TITLE
[tests] re-add accidental removal

### DIFF
--- a/common/setup.cfg
+++ b/common/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test = trial
+
 [pep8]
 exclude = versioneer.py,_version.py,ddocs.py,*.egg,build
 ignore = E731


### PR DESCRIPTION
when copying a generic config file over in previous commit