### PR TITLE
Fixed http target sync tests

### DIFF
--- a/client/src/leap/soledad/client/api.py
+++ b/client/src/leap/soledad/client/api.py
@@ -213,8 +213,7 @@ class Soledad(object):
         soledad_assert_type(self._passphrase, unicode)
 
         def initialize(attr, val):
-            return (getattr(self, attr, None) is None
-                    and setattr(self, attr, val))
+            return (getattr(self, attr, None) is None and setattr(self, attr, val))
 
         initialize("_secrets_path", os.path.join(
             self.default_prefix, self.secrets_file_name))

--- a/client/src/leap/soledad/client/http_target.py
+++ b/client/src/leap/soledad/client/http_target.py
@@ -527,8 +527,11 @@ class SoledadHTTPSyncTarget(SyncTarget):
             raise errors.BrokenSyncStream
         data = parts[1:-1]
         # decode metadata
-        line, comma = utils.check_and_strip_comma(data[0])
-        metadata = None
+        try:
+            line, comma = utils.check_and_strip_comma(data[0])
+            metadata = None
+        except (IndexError):
+            raise errors.BrokenSyncStream
         try:
             metadata = json.loads(line)
             new_generation = metadata['new_generation']

--- a/client/src/leap/soledad/client/http_target.py
+++ b/client/src/leap/soledad/client/http_target.py
@@ -534,7 +534,7 @@ class SoledadHTTPSyncTarget(SyncTarget):
             new_generation = metadata['new_generation']
             new_transaction_id = metadata['new_transaction_id']
             number_of_changes = metadata['number_of_changes']
-        except (json.JSONDecodeError, KeyError):
+        except (ValueError, KeyError):
             raise errors.BrokenSyncStream
         # make sure we have replica_uid from fresh new dbs
         if self._ensure_callback and 'replica_uid' in metadata:

--- a/common/src/leap/soledad/common/tests/test_sqlcipher_sync.py
+++ b/common/src/leap/soledad/common/tests/test_sqlcipher_sync.py
@@ -29,7 +29,7 @@ from u1db import (
 from testscenarios import TestWithScenarios
 
 from leap.soledad.common.crypto import ENC_SCHEME_KEY
-from leap.soledad.client.target import SoledadSyncTarget
+from leap.soledad.client.http_target import SoledadHTTPSyncTarget
 from leap.soledad.client.crypto import decrypt_doc_dict
 from leap.soledad.client.sqlcipher import (
     SQLCipherDatabase,
@@ -55,7 +55,7 @@ def sync_via_synchronizer_and_soledad(test, db_source, db_target,
     if trace_hook:
         test.skipTest("full trace hook unsupported over http")
     path = test._http_at[db_target]
-    target = SoledadSyncTarget.connect(
+    target = SoledadHTTPSyncTarget.connect(
         test.getURL(path), test._soledad._crypto)
     target.set_token_credentials('user-uuid', 'auth-token')
     if trace_hook_shallow:
@@ -300,7 +300,7 @@ class SQLCipherDatabaseSyncTests(
 def _make_local_db_and_token_http_target(test, path='test'):
     test.startServer()
     db = test.request_state._create_database(os.path.basename(path))
-    st = SoledadSyncTarget.connect(
+    st = SoledadHTTPSyncTarget.connect(
         test.getURL(path), crypto=test._soledad._crypto)
     st.set_token_credentials('user-uuid', 'auth-token')
     return db, st

--- a/common/src/leap/soledad/common/tests/test_sync.py
+++ b/common/src/leap/soledad/common/tests/test_sync.py
@@ -27,7 +27,7 @@ from twisted.internet import defer
 from testscenarios import TestWithScenarios
 
 from leap.soledad.common import couch
-from leap.soledad.client import target
+from leap.soledad.client import http_target as target
 from leap.soledad.client import sync
 from leap.soledad.server import SoledadApp
 
@@ -213,7 +213,7 @@ class TestSoledadDbSync(
         target_url = self.getURL(target_name)
         return sync.SoledadSynchronizer(
             self.db,
-            target.SoledadSyncTarget(
+            target.SoledadHTTPSyncTarget(
                 target_url,
                 crypto=self._soledad._crypto,
                 **extra)).sync(autocreate=True,


### PR DESCRIPTION
Fixed the parser tests on http target after the changes, one exception was being expected but didn't exist so I fixed that in the code too.

The last commit from Leap left a Pep8 warning, that was fixed in the last commit here