### PR TITLE
[bug] review some of the close methods

### DIFF
--- a/client/src/leap/soledad/client/encdecpool.py
+++ b/client/src/leap/soledad/client/encdecpool.py
@@ -74,6 +74,8 @@ class SyncEncryptDecryptPool(object):
         self._started = True
 
     def stop(self):
+        if not self._started:
+            return
         self._started = False
         self._destroy_pool()
         # maybe cancel the next delayed call

--- a/client/src/leap/soledad/client/http_target/api.py
+++ b/client/src/leap/soledad/client/http_target/api.py
@@ -32,8 +32,13 @@ class SyncTargetAPI(SyncTarget):
     Declares public methods and implements u1db.SyncTarget.
     """
 
+    @defer.inlineCallbacks
     def close(self):
-        self._http.close()
+        if self._sync_enc_pool:
+            self._sync_enc_pool.stop()
+        if self._sync_decr_pool:
+            self._sync_decr_pool.stop()
+        yield self._http.close()
 
     def set_creds(self, creds):
         """

--- a/client/src/leap/soledad/client/sqlcipher.py
+++ b/client/src/leap/soledad/client/sqlcipher.py
@@ -559,6 +559,7 @@ class SQLCipherU1DBSync(SQLCipherDatabase):
         """
         Close the syncer and syncdb orderly
         """
+        super(SQLCipherU1DBSync, self).close()
         # close all open syncers
         for url in self._syncers.keys():
             _, syncer = self._syncers[url]

--- a/common/src/leap/soledad/common/tests/util.py
+++ b/common/src/leap/soledad/common/tests/util.py
@@ -345,20 +345,9 @@ class CouchDBTestCase(unittest.TestCase, MockedSharedDBTest):
         """
         Make sure we have a CouchDB instance for a test.
         """
-        server = self.couch_server = couchdb.Server()
-        self.previous_dbs = set([db for db in server])
         self.couch_port = 5984
         self.couch_url = 'http://localhost:%d' % self.couch_port
-
-    def tearDown(self):
-        """
-        Stop CouchDB instance for test.
-        """
-        current_dbs = set([db for db in self.couch_server])
-        remaining_dbs = current_dbs - self.previous_dbs
-        if remaining_dbs:
-            raise Exception("tests created %s and didn't clean up!",
-                            remaining_dbs)
+        self.couch_server = couchdb.Server(self.couch_url)
 
     def delete_db(self, name):
         try:


### PR DESCRIPTION
We are getting "too many files open" while running tests with 1024 max
files open. This is a leak from close methods. Some of them should be fixed
on this commit, but further investigation may be necessary.