### PR TITLE
[feat] use async events client

### DIFF
--- a/client/pkg/requirements-leap.pip
+++ b/client/pkg/requirements-leap.pip
@@ -1,2 +1,2 @@
-leap.common>=0.4.1
-leap.soledad.common>=0.6.5
+leap.common>=0.4.3
+leap.soledad.common>=0.7.0

--- a/client/src/leap/soledad/client/api.py
+++ b/client/src/leap/soledad/client/api.py
@@ -718,7 +718,7 @@ class Soledad(object):
             return failure
 
         def _emit_done_data_sync(passthrough):
-            soledad_events.emit(
+            soledad_events.emit_async(
                 soledad_events.SOLEDAD_DONE_DATA_SYNC, self.uuid)
             return passthrough
 

--- a/client/src/leap/soledad/client/events.py
+++ b/client/src/leap/soledad/client/events.py
@@ -20,7 +20,7 @@
 Signaling functions.
 """
 
-from leap.common.events import emit
+from leap.common.events import emit_async
 from leap.common.events import catalog
 
 
@@ -40,7 +40,7 @@ SOLEDAD_SYNC_RECEIVE_STATUS = catalog.SOLEDAD_SYNC_RECEIVE_STATUS
 
 __all__ = [
     "catalog",
-    "emit",
+    "emit_async",
     "SOLEDAD_CREATING_KEYS",
     "SOLEDAD_DONE_CREATING_KEYS",
     "SOLEDAD_DOWNLOADING_KEYS",

--- a/client/src/leap/soledad/client/http_target/fetch.py
+++ b/client/src/leap/soledad/client/http_target/fetch.py
@@ -21,7 +21,7 @@ from u1db.remote import utils
 from twisted.internet import defer
 from leap.soledad.common.document import SoledadDocument
 from leap.soledad.client.events import SOLEDAD_SYNC_RECEIVE_STATUS
-from leap.soledad.client.events import emit
+from leap.soledad.client.events import emit_async
 from leap.soledad.client.crypto import is_symmetrically_encrypted
 from leap.soledad.client.encdecpool import SyncDecrypterPool
 from leap.soledad.client.http_target.support import RequestBody
@@ -245,7 +245,7 @@ class HTTPDocFetcher(object):
 
 def _emit_receive_status(received_docs, total):
     content = {'received': received_docs, 'total': total}
-    emit(SOLEDAD_SYNC_RECEIVE_STATUS, content)
+    emit_async(SOLEDAD_SYNC_RECEIVE_STATUS, content)
 
     msg = "%d/%d" % (received_docs, total)
     logger.debug("Sync receive status: %s" % msg)

--- a/client/src/leap/soledad/client/http_target/send.py
+++ b/client/src/leap/soledad/client/http_target/send.py
@@ -17,7 +17,7 @@
 import json
 import logging
 from twisted.internet import defer
-from leap.soledad.client.events import emit
+from leap.soledad.client.events import emit_async
 from leap.soledad.client.events import SOLEDAD_SYNC_SEND_STATUS
 from leap.soledad.client.http_target.support import RequestBody
 logger = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class HTTPDocSender(object):
 
 def _emit_send_status(idx, total):
     content = {'sent': idx, 'total': total}
-    emit(SOLEDAD_SYNC_SEND_STATUS, content)
+    emit_async(SOLEDAD_SYNC_SEND_STATUS, content)
 
     msg = "%d/%d" % (idx, total)
     logger.debug("Sync send status: %s" % msg)

--- a/client/src/leap/soledad/client/secrets.py
+++ b/client/src/leap/soledad/client/secrets.py
@@ -432,13 +432,13 @@ class SoledadSecrets(object):
         :return: a document with encrypted key material in its contents
         :rtype: document.SoledadDocument
         """
-        events.emit(events.SOLEDAD_DOWNLOADING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_DOWNLOADING_KEYS, self._uuid)
         db = self._shared_db
         if not db:
             logger.warning('No shared db found')
             return
         doc = db.get_doc(self._shared_db_doc_id())
-        events.emit(events.SOLEDAD_DONE_DOWNLOADING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_DONE_DOWNLOADING_KEYS, self._uuid)
         return doc
 
     def _put_secrets_in_shared_db(self):
@@ -461,13 +461,13 @@ class SoledadSecrets(object):
         # fill doc with encrypted secrets
         doc.content = self._export_recovery_document()
         # upload secrets to server
-        events.emit(events.SOLEDAD_UPLOADING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_UPLOADING_KEYS, self._uuid)
         db = self._shared_db
         if not db:
             logger.warning('No shared db found')
             return
         db.put_doc(doc)
-        events.emit(events.SOLEDAD_DONE_UPLOADING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_DONE_UPLOADING_KEYS, self._uuid)
 
     #
     # Management of secret for symmetric encryption.
@@ -587,13 +587,13 @@ class SoledadSecrets(object):
         :return: The id of the generated secret.
         :rtype: str
         """
-        events.emit(events.SOLEDAD_CREATING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_CREATING_KEYS, self._uuid)
         # generate random secret
         secret = os.urandom(self.GEN_SECRET_LENGTH)
         secret_id = sha256(secret).hexdigest()
         self._secrets[secret_id] = secret
         self._store_secrets()
-        events.emit(events.SOLEDAD_DONE_CREATING_KEYS, self._uuid)
+        events.emit_async(events.SOLEDAD_DONE_CREATING_KEYS, self._uuid)
         return secret_id
 
     def _store_secrets(self):


### PR DESCRIPTION
in this way we use the reactor pattern to dispatch the events, instead
of having the overhead of running a separate client thread.

- Resolves: #7274