### PR TITLE
[bug] set the received active secret before saving local file

### DIFF
--- a/client/changes/bug_set-active-secret
+++ b/client/changes/bug_set-active-secret
@@ -1,0 +1,1 @@
+o [bug] Set active secret before saving local file.


### PR DESCRIPTION
- bug: we were dumping the received secrets locally to disk *before*
  setting the received property for the active secret, and therefore the
  'active_secret' was always marked as null.
- refactor common code into an utility method.