### PR TITLE
[feat] read netrc path from configuration file

### DIFF
--- a/server/changes/create_db_cmd
+++ b/server/changes/create_db_cmd
@@ -1,3 +1,4 @@
   o Adds a new config parameter 'create_cmd', which allows sysadmin to specify
   which command will create a database. That command was added in
   pkg/create-user-db and debian package automates steps needed for sudo access.
+  o Read netrc path from configuration file for create-user-db command. 

--- a/server/pkg/create-user-db
+++ b/server/pkg/create-user-db
@@ -21,6 +21,7 @@ import netrc
 import argparse
 from leap.soledad.common.couch import CouchDatabase
 from leap.soledad.common.couch import is_db_name_valid
+from leap.soledad.server import load_configuration
 
 
 description = """
@@ -30,7 +31,7 @@ This is meant to be used by Soledad Server.
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument('dbname', metavar='user-d34db33f', type=str,
                     help='database name on the format user-{uuid4}')
-NETRC_PATH = '/etc/couchdb/couchdb-admin.netrc'
+NETRC_PATH = load_configuration('/etc/leap/soledad-server.conf')['admin_netrc']
 
 
 def url_for_db(dbname):

--- a/server/src/leap/soledad/server/__init__.py
+++ b/server/src/leap/soledad/server/__init__.py
@@ -283,19 +283,20 @@ def load_configuration(file_path):
     @return: A dictionary with the configuration.
     @rtype: dict
     """
-    conf = {
+    defaults = {
         'couch_url': 'http://localhost:5984',
-        'create_cmd': None
+        'create_cmd': None,
+        'admin_netrc': '/etc/couchdb/couchdb-admin.netrc',
     }
     config = configparser.ConfigParser()
     config.read(file_path)
     if 'soledad-server' in config:
-        for key in conf:
+        for key in defaults:
             if key in config['soledad-server']:
-                conf[key] = config['soledad-server'][key]
+                defaults[key] = config['soledad-server'][key]
     # TODO: implement basic parsing/sanitization of options comming from
     # config file.
-    return conf
+    return defaults
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
netrc file was hardcoded inside create-user-db. Now it reads the path
from /etc/leap/soledad-server.conf as done on server process.
The new configuration property is called 'admin_netrc'.