### PR TITLE
[bug] increase http request timeout time to 90s

### DIFF
--- a/client/src/leap/soledad/client/http_target/__init__.py
+++ b/client/src/leap/soledad/client/http_target/__init__.py
@@ -87,4 +87,8 @@ class SoledadHTTPSyncTarget(SyncTargetAPI, HTTPDocSender, HTTPDocFetcher):
         # asynchronous encryption/decryption attributes
         self._decryption_callback = None
         self._sync_decr_pool = None
-        self._http = HTTPClient(cert_file)
+
+        # XXX Increasing timeout of simple requests to avoid chances of hitting
+        # the duplicated syncing bug. This could be reduced to the 30s default
+        # after implementing Cancellable Sync. See #7382
+        self._http = HTTPClient(cert_file, timeout=90)


### PR DESCRIPTION
this is a workaroud to reduce the chances of failed sync due to
timeouts. this should be properly tackled by:

1. implementing proper cancellable for the sync operation.
2. implementing a retry count at the level of a single request, handled
internally by soledad.

in this way we can remove the retries logic from the soledadbootstrapper
in the bitmask client.

- Related: #7382