### PR TITLE
[bug] reduce overall sync session caching to 120s in order to prevent file handlers leak

### DIFF
--- a/server/src/leap/soledad/server/sync.py
+++ b/server/src/leap/soledad/server/sync.py
@@ -185,7 +185,7 @@ class SyncResource(http_app.SyncResource):
         :type ensure: bool
         """
         # create or open the database
-        cache = get_cache_for('db-' + sync_id + self.dbname)
+        cache = get_cache_for('db-' + sync_id + self.dbname, expire=120)
         if ensure:
             db, self.replica_uid = self.state.ensure_database(self.dbname)
         elif cache and 'instance' in cache:

--- a/server/src/leap/soledad/server/sync.py
+++ b/server/src/leap/soledad/server/sync.py
@@ -188,12 +188,9 @@ class SyncResource(http_app.SyncResource):
         cache = get_cache_for('db-' + sync_id + self.dbname, expire=120)
         if ensure:
             db, self.replica_uid = self.state.ensure_database(self.dbname)
-        elif cache and 'instance' in cache:
-            db = cache['instance']
         else:
             db = self.state.open_database(self.dbname)
         db.init_caching(cache)
-        cache['instance'] = db
         # validate the information the client has about server replica
         db.validate_gen_and_trans_id(
             last_known_generation, last_known_trans_id)


### PR DESCRIPTION
It was 3600s, but closing connections seems to yet depend on garbage
collection and now causes server to leak file handlers. 120s should be
enough to a sync session finish. Also, lowering this value will only
make very long syncs poke couch every 2 minutes, while raising
this value will keep memory busy for useless time.
I couldn't find a proper place to call close on the session, but I will keep in mind that maybe, in the future, 'session' on CouchDB should be something shared to reuse connections instead of creating more.