### PR TITLE
[feat] read security doc from configuration

### DIFF
--- a/common/src/leap/soledad/common/couch.py
+++ b/common/src/leap/soledad/common/couch.py
@@ -488,7 +488,8 @@ class CouchDatabase(CommonBackend):
         security_config = security_config or {}
         security = self._database.resource.get_json('_security')[2]
         security['members'] = {'names': [], 'roles': []}
-        security['members']['names'] = security_config.get('members', ['soledad'])
+        security['members']['names'] = security_config.get('members',
+                                                           ['soledad'])
         security['members']['roles'] = security_config.get('members_roles', [])
         security['admins'] = {'names': [], 'roles': []}
         security['admins']['names'] = security_config.get('admins', [])

--- a/common/src/leap/soledad/common/couch.py
+++ b/common/src/leap/soledad/common/couch.py
@@ -70,6 +70,23 @@ logger = logging.getLogger(__name__)
 COUCH_TIMEOUT = 120  # timeout for transfers between Soledad server and Couch
 
 
+def list_users_dbs(couch_url):
+    """
+    Retrieves a list with all databases that starts with 'user-' on CouchDB.
+    Those databases belongs to users. So, the list will contain all the
+    database names in the form of 'user-{uuid4}'.
+
+    :param couch_url: The couch url with needed credentials
+    :type couch_url: str
+
+    :return: The list of all database names from users.
+    :rtype: [str]
+    """
+    with couch_server(couch_url) as server:
+        users = [dbname for dbname in server if dbname.startswith('user-')]
+    return users
+
+
 class InvalidURLError(Exception):
 
     """

--- a/common/src/leap/soledad/common/tests/fixture_soledad.conf
+++ b/common/src/leap/soledad/common/tests/fixture_soledad.conf
@@ -1,0 +1,10 @@
+[soledad-server]
+couch_url   = http://soledad:passwd@localhost:5984
+create_cmd  = sudo -u soledad-admin /usr/bin/create-user-db
+admin_netrc = /etc/couchdb/couchdb-soledad-admin.netrc
+
+[database-security]
+members       = user1, user2
+members_roles = role1, role2
+admins        = user3, user4
+admins_roles  = role3, role3

--- a/common/src/leap/soledad/common/tests/test_couch.py
+++ b/common/src/leap/soledad/common/tests/test_couch.py
@@ -1530,10 +1530,14 @@ class CouchDatabaseExceptionsTests(CouchDBTestCase):
         self.db.ensure_security_ddoc(configuration)
 
         security_ddoc = self.db._database.resource.get_json('_security')[2]
-        self.assertEquals(configuration['admins'], security_ddoc['admins']['names'])
-        self.assertEquals(configuration['admins_roles'], security_ddoc['admins']['roles'])
-        self.assertEquals(configuration['members'], security_ddoc['members']['names'])
-        self.assertEquals(configuration['members_roles'], security_ddoc['members']['roles'])
+        self.assertEquals(configuration['admins'],
+                          security_ddoc['admins']['names'])
+        self.assertEquals(configuration['admins_roles'],
+                          security_ddoc['admins']['roles'])
+        self.assertEquals(configuration['members'],
+                          security_ddoc['members']['names'])
+        self.assertEquals(configuration['members_roles'],
+                          security_ddoc['members']['roles'])
 
 
 class DatabaseNameValidationTest(unittest.TestCase):

--- a/common/src/leap/soledad/common/tests/test_server.py
+++ b/common/src/leap/soledad/common/tests/test_server.py
@@ -22,7 +22,7 @@ import tempfile
 import mock
 import time
 import binascii
-import pkg_resources
+from pkg_resources import resource_filename
 from uuid import uuid4
 
 from urlparse import urljoin
@@ -605,16 +605,19 @@ class ConfigurationParsingTest(unittest.TestCase):
 
     def test_security_values_configuration(self):
         # given
-        config_path = pkg_resources.resource_filename('leap.soledad.common.tests',
-                                                      'fixture_soledad.conf')
+        config_path = resource_filename('leap.soledad.common.tests',
+                                        'fixture_soledad.conf')
         # when
         config = load_configuration(config_path)
 
         # then
         expected = {'soledad-server': {
-                    'couch_url': 'http://soledad:passwd@localhost:5984',
-                    'create_cmd': 'sudo -u soledad-admin /usr/bin/create-user-db',
-                    'admin_netrc': '/etc/couchdb/couchdb-soledad-admin.netrc',
+                    'couch_url':
+                        'http://soledad:passwd@localhost:5984',
+                    'create_cmd':
+                        'sudo -u soledad-admin /usr/bin/create-user-db',
+                    'admin_netrc':
+                        '/etc/couchdb/couchdb-soledad-admin.netrc',
                     },
                     'database-security': {
                     'members': ['user1', 'user2'],

--- a/server/changes/feat_configurable_ensure
+++ b/server/changes/feat_configurable_ensure
@@ -2,4 +2,4 @@ o 'create-user-db' script now can be configured from soledad-server.conf
   when generating the user's security document.
 o Migrating a user's database to newest design documents is now possible by
   using a parameter '--migrate-all' on 'create-user-db' script.
- 
+o Remove tsafe monkeypatch from SSL lib, as it was needed for Twisted <12

--- a/server/changes/feat_configurable_ensure
+++ b/server/changes/feat_configurable_ensure
@@ -1,0 +1,5 @@
+o 'create-user-db' script now can be configured from soledad-server.conf
+  when generating the user's security document.
+o Migrating a user's database to newest design documents is now possible by
+  using a parameter '--migrate-all' on 'create-user-db' script.
+ 

--- a/server/pkg/create-user-db
+++ b/server/pkg/create-user-db
@@ -31,7 +31,8 @@ This is meant to be used by Soledad Server.
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument('dbname', metavar='user-d34db33f', type=str,
                     help='database name on the format user-{uuid4}')
-NETRC_PATH = load_configuration('/etc/soledad/soledad-server.conf')['admin_netrc']
+CONF = load_configuration('/etc/soledad/soledad-server.conf')
+NETRC_PATH = CONF['soledad-server']['admin_netrc']
 
 
 def url_for_db(dbname):
@@ -54,7 +55,9 @@ if __name__ == '__main__':
         print ("Invalid name! %s" % args.dbname)
         sys.exit(1)
     url = url_for_db(args.dbname)
+    db_security = CONF['database-security']
     db = CouchDatabase.open_database(url=url, create=True,
-                                     replica_uid=None, ensure_ddocs=True)
+                                     replica_uid=None, ensure_ddocs=True,
+                                     database_security=db_security)
     print ('success! Created %s, replica_uid: %s' %
            (db._dbname, db.replica_uid))

--- a/server/pkg/create-user-db
+++ b/server/pkg/create-user-db
@@ -21,6 +21,7 @@ import netrc
 import argparse
 from leap.soledad.common.couch import CouchDatabase
 from leap.soledad.common.couch import is_db_name_valid
+from leap.soledad.common.couch import list_users_dbs
 from leap.soledad.server import load_configuration
 
 
@@ -30,7 +31,10 @@ This is meant to be used by Soledad Server.
 """
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument('dbname', metavar='user-d34db33f', type=str,
+                    default='', nargs='?',
                     help='database name on the format user-{uuid4}')
+parser.add_argument('--migrate-all', action='store_true',
+                    help="recreate all design docs for all existing account")
 CONF = load_configuration('/etc/soledad/soledad-server.conf')
 NETRC_PATH = CONF['soledad-server']['admin_netrc']
 
@@ -49,15 +53,34 @@ def url_for_db(dbname):
     return url
 
 
-if __name__ == '__main__':
-    args = parser.parse_args()
-    if not is_db_name_valid(args.dbname):
-        print ("Invalid name! %s" % args.dbname)
+def ensure_database(dbname):
+    """
+    This method will ensure that a database named `dbname` will exist
+    or created if it doesn't. Calling it twice will ensure that design
+    documents are present and updated.
+    The database name has to match this criteria to be considered valid:
+    user-[a-f0-9]+
+
+    :param dbname: name of the user database
+    :type dbname: str
+    """
+    if not is_db_name_valid(dbname):
+        print ("Invalid name! %s" % dbname)
         sys.exit(1)
-    url = url_for_db(args.dbname)
+    url = url_for_db(dbname)
     db_security = CONF['database-security']
     db = CouchDatabase.open_database(url=url, create=True,
                                      replica_uid=None, ensure_ddocs=True,
                                      database_security=db_security)
-    print ('success! Created %s, replica_uid: %s' %
+    print ('success! Ensured that database %s exists, with replica_uid: %s' %
            (db._dbname, db.replica_uid))
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    if args.migrate_all:
+        couch_url = url_for_db('')
+        for dbname in list_users_dbs(couch_url):
+            ensure_database(dbname)
+    else:
+        ensure_database(args.dbname)

--- a/server/src/leap/soledad/server/__init__.py
+++ b/server/src/leap/soledad/server/__init__.py
@@ -94,12 +94,6 @@ from u1db.remote import http_app, utils
 
 from ._version import get_versions
 
-# Keep OpenSSL's tsafe before importing Twisted submodules so we can put
-# it back if Twisted==12.0.0 messes with it.
-from OpenSSL import tsafe
-
-from twisted import version
-
 from leap.soledad.server.auth import SoledadTokenAuthMiddleware
 from leap.soledad.server.gzip_middleware import GzipMiddleware
 from leap.soledad.server.lock_resource import LockResource
@@ -111,13 +105,6 @@ from leap.soledad.server.sync import (
 
 from leap.soledad.common import SHARED_DB_NAME
 from leap.soledad.common.couch import CouchServerState
-
-old_tsafe = tsafe
-
-if version.base() == "12.0.0":
-    # Put OpenSSL's tsafe back into place. This can probably be removed if we
-    # come to use Twisted>=12.3.0.
-    sys.modules['OpenSSL.tsafe'] = old_tsafe
 
 # ----------------------------------------------------------------------------
 # Soledad WSGI application

--- a/server/src/leap/soledad/server/__init__.py
+++ b/server/src/leap/soledad/server/__init__.py
@@ -306,7 +306,8 @@ def load_configuration(file_path):
                 if key in config[section]:
                     defaults[section][key] = config[section][key]
     for key, value in defaults['database-security'].iteritems():
-        if type(value) is not unicode: continue
+        if type(value) is not unicode:
+            continue
         defaults['database-security'][key] = \
                 [item.strip() for item in value.split(',')]
     # TODO: implement basic parsing/sanitization of options comming from


### PR DESCRIPTION
LEAP Platform needs to granularly allow access on user database for
other services, like mx. This is now possible by editing
soledad-server.conf file. A new section 'database-security' was added
and it is parsed during 'create-user-db' to be set on security design
document, present on every per-user database.