### PR TITLE
[bug] fix indirect dependency on couchdb for client

### DIFF
--- a/client/src/leap/soledad/client/sync.py
+++ b/client/src/leap/soledad/client/sync.py
@@ -22,7 +22,7 @@ import logging
 from twisted.internet import defer
 
 from u1db import errors
-from leap.soledad.common.couch.errors import MissingDesignDocError
+from leap.soledad.common.errors import BackendNotReadyError
 from u1db.sync import Synchronizer
 
 
@@ -74,7 +74,7 @@ class SoledadSynchronizer(Synchronizer):
             (self.target_replica_uid, target_gen, target_trans_id,
              target_my_gen, target_my_trans_id) = yield \
                 sync_target.get_sync_info(self.source._replica_uid)
-        except (errors.DatabaseDoesNotExist, MissingDesignDocError) as e:
+        except (errors.DatabaseDoesNotExist, BackendNotReadyError) as e:
             logger.debug("Database isn't ready on server. Will be created.")
             logger.debug("Reason: %s", e.__class__)
             self.target_replica_uid = None

--- a/common/changes/next-changelog.rst
+++ b/common/changes/next-changelog.rst
@@ -1,0 +1,29 @@
+0.8.0 - xxx
++++++++++++++++++++++++++++++++
+
+Please add lines to this file, they will be moved to the CHANGELOG.rst during
+the next release.
+
+There are two template lines for each category, use them as reference.
+
+I've added a new category `Misc` so we can track doc/style/packaging stuff.
+
+Features
+~~~~~~~~
+- `#1234 <https://leap.se/code/issues/1234>`_: Description of the new feature corresponding with issue #1234.
+- New feature without related issue number.
+
+Bugfixes
+~~~~~~~~
+- `#7626 <https://leap.se/code/issues/7626>`_: Subclass a leaky leap.common.couch exception to avoid depending on couch.
+- `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.
+- Bugfix without related issue number.
+
+Misc
+~~~~
+- `#1236 <https://leap.se/code/issues/1236>`_: Description of the new feature corresponding with issue #1236.
+- Some change without issue number.
+
+Known Issues
+~~~~~~~~~~~~
+- `#1236 <https://leap.se/code/issues/1236>`_: Description of the known issue corresponding with issue #1236.

--- a/common/src/leap/soledad/common/couch/errors.py
+++ b/common/src/leap/soledad/common/couch/errors.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-from leap.soledad.common.errors import SoledadError
+from leap.soledad.common.errors import SoledadError, BackendNotReadyError
 from leap.soledad.common.errors import register_exception
 
 """
@@ -23,7 +23,7 @@ Specific errors that can be raised by CouchDatabase.
 
 
 @register_exception
-class MissingDesignDocError(SoledadError):
+class MissingDesignDocError(BackendNotReadyError):
 
     """
     Raised when trying to access a missing couch design document.

--- a/common/src/leap/soledad/common/errors.py
+++ b/common/src/leap/soledad/common/errors.py
@@ -143,3 +143,11 @@ class InvalidURLError(Exception):
     """
     Exception raised when Soledad encounters a malformed URL.
     """
+
+
+@register_exception
+class BackendNotReadyError(SoledadError):
+    """
+    Generic exception raised when the backend is not ready to dispatch a client
+    request.
+    """


### PR DESCRIPTION
by subclassing the MissingDesignDocError, we don't have to import the
soledad.common.couch submodule into the soledad.client.sync

- Resolves: #7626