### PR TITLE
[bug] updated SOLEDAD_DONE_DOWNLOADING_KEYS trigger

### DIFF
--- a/common/src/leap/soledad/common/tests/test_soledad.py
+++ b/common/src/leap/soledad/common/tests/test_soledad.py
@@ -284,16 +284,16 @@ class SoledadSignalingTestCase(BaseSoledadTest):
         )
         self._pop_mock_call(soledad.client.secrets.events.emit_async)
         soledad.client.secrets.events.emit_async.assert_called_with(
-            catalog.SOLEDAD_DONE_DOWNLOADING_KEYS, user_data 
+            catalog.SOLEDAD_DONE_DOWNLOADING_KEYS, user_data
         )
         # uploading keys signals
         self._pop_mock_call(soledad.client.secrets.events.emit_async)
         soledad.client.secrets.events.emit_async.assert_called_with(
-            catalog.SOLEDAD_UPLOADING_KEYS, user_data 
+            catalog.SOLEDAD_UPLOADING_KEYS, user_data
         )
         self._pop_mock_call(soledad.client.secrets.events.emit_async)
         soledad.client.secrets.events.emit_async.assert_called_with(
-            catalog.SOLEDAD_DONE_UPLOADING_KEYS, user_data 
+            catalog.SOLEDAD_DONE_UPLOADING_KEYS, user_data
         )
         # assert db was locked and unlocked
         sol.shared_db.lock.assert_called_with()


### PR DESCRIPTION
That event was triggering with the user uuid instead
of the user_data, adapted that to conform with the rest
of the events