### PR TITLE
Fix sync timeout

### DIFF
--- a/common/src/leap/soledad/common/tests/test_sync_deferred.py
+++ b/common/src/leap/soledad/common/tests/test_sync_deferred.py
@@ -148,6 +148,8 @@ class TestSoledadDbSyncDeferredEncDecr(
         replica_uid = self._soledad._dbpool.replica_uid
         sync_db = self._soledad._sync_db
         sync_enc_pool = self._soledad._sync_enc_pool
+        dbsyncer = self._soledad._dbsyncer  # Soledad.sync uses the dbsyncer
+
         target = soledad_sync_target(
             self, self.db2._dbname,
             source_replica_uid=replica_uid,
@@ -155,7 +157,7 @@ class TestSoledadDbSyncDeferredEncDecr(
             sync_enc_pool=sync_enc_pool)
         self.addCleanup(target.close)
         return sync.SoledadSynchronizer(
-            self.db1,
+            dbsyncer,
             target).sync(defer_decryption=True)
 
     def wait_for_sync(self):


### PR DESCRIPTION
The sequential handling of downloading and inserting docs blocked the twisted event loop (see the _process_decrypted_docs in the diff below)

```python
         for doc_fields in insertable:
             self._insert_decrypted_local_doc(*doc_fields)
```

Move the insertion into a background thread to keep the event loop free and able to handle the download requests
