### PR TITLE
[feat] use cryptography instead of pycryptopp

### DIFF
--- a/client/changes/feat_use_cryptography
+++ b/client/changes/feat_use_cryptography
@@ -1,0 +1,1 @@
+o Use cryptography instead of pycryptopp. Stick with AES-CTR.

--- a/client/pkg/requirements.pip
+++ b/client/pkg/requirements.pip
@@ -1,7 +1,6 @@
 pysqlcipher>2.6.3
 u1db
 scrypt
-pycryptopp
 cchardet
 zope.proxy
 twisted


### PR DESCRIPTION
cryptography comes from OpenSSL and Twisted dependencies, so it's
already installed.
This commit removes a compiled dependency, also possibly making it
easier to use on Windows.