### PR TITLE
[Refactor] bye multiprocessing

### DIFF
--- a/client/changes/next-changelog.rst
+++ b/client/changes/next-changelog.rst
@@ -23,6 +23,7 @@ Misc
 - Refactor bootstrap to remove shared db lock.
 - `#1236 <https://leap.se/code/issues/1236>`_: Description of the new feature corresponding with issue #1236.
 - Some change without issue number.
+- Removed multiprocessing from encdecpool with some extra refactoring.
 
 Known Issues
 ~~~~~~~~~~~~

--- a/client/src/leap/soledad/client/http_target/fetch.py
+++ b/client/src/leap/soledad/client/http_target/fetch.py
@@ -19,7 +19,6 @@ import json
 from u1db import errors
 from u1db.remote import utils
 from twisted.internet import defer
-from twisted.internet import threads
 from leap.soledad.common.document import SoledadDocument
 from leap.soledad.client.events import SOLEDAD_SYNC_RECEIVE_STATUS
 from leap.soledad.client.events import emit_async
@@ -76,7 +75,7 @@ class HTTPDocFetcher(object):
             last_known_generation, last_known_trans_id,
             sync_id, 0)
         self._received_docs = 0
-        number_of_changes, ngen, ntrans = yield self._insert_received_doc(doc, 1, 1)
+        number_of_changes, ngen, ntrans = self._insert_received_doc(doc, 1, 1)
 
         if ngen:
             new_generation = ngen
@@ -138,7 +137,6 @@ class HTTPDocFetcher(object):
             body=str(body),
             content_type='application/x-soledad-sync-get')
 
-    @defer.inlineCallbacks
     def _insert_received_doc(self, response, idx, total):
         """
         Insert a received document into the local replica.
@@ -152,8 +150,7 @@ class HTTPDocFetcher(object):
         """
         new_generation, new_transaction_id, number_of_changes, doc_id, \
             rev, content, gen, trans_id = \
-            (yield threads.deferToThread(self._parse_received_doc_response,
-                                         response))
+            self._parse_received_doc_response(response)
         if doc_id is not None:
             # decrypt incoming document and insert into local database
             # -------------------------------------------------------------
@@ -188,7 +185,7 @@ class HTTPDocFetcher(object):
         self._received_docs += 1
         user_data = {'uuid': self.uuid, 'userid': self.userid}
         _emit_receive_status(user_data, self._received_docs, total)
-        defer.returnValue((number_of_changes, new_generation, new_transaction_id))
+        return number_of_changes, new_generation, new_transaction_id
 
     def _parse_received_doc_response(self, response):
         """

--- a/client/src/leap/soledad/client/http_target/fetch.py
+++ b/client/src/leap/soledad/client/http_target/fetch.py
@@ -81,9 +81,6 @@ class HTTPDocFetcher(object):
             new_generation = ngen
             new_transaction_id = ntrans
 
-        if defer_decryption:
-            self._sync_decr_pool.start(number_of_changes)
-
         # ---------------------------------------------------------------------
         # maybe receive the rest of the documents
         # ---------------------------------------------------------------------
@@ -151,6 +148,10 @@ class HTTPDocFetcher(object):
         new_generation, new_transaction_id, number_of_changes, doc_id, \
             rev, content, gen, trans_id = \
             self._parse_received_doc_response(response)
+
+        if self._sync_decr_pool and not self._sync_decr_pool.running:
+            self._sync_decr_pool.start(number_of_changes)
+
         if doc_id is not None:
             # decrypt incoming document and insert into local database
             # -------------------------------------------------------------

--- a/client/src/leap/soledad/client/sqlcipher.py
+++ b/client/src/leap/soledad/client/sqlcipher.py
@@ -278,7 +278,7 @@ class SQLCipherDatabase(sqlite_backend.SQLitePartialExpandDatabase):
         doc_rev = sqlite_backend.SQLitePartialExpandDatabase.put_doc(self, doc)
         if self.defer_encryption:
             # TODO move to api?
-            self._sync_enc_pool.enqueue_doc_for_encryption(doc)
+            self._sync_enc_pool.encrypt_doc(doc)
         return doc_rev
 
     #

--- a/common/src/leap/soledad/common/tests/test_server.py
+++ b/common/src/leap/soledad/common/tests/test_server.py
@@ -481,9 +481,8 @@ class EncryptedSyncTestCase(
         """
         Test if Soledad can sync very large files.
         """
-        self.skipTest(
-                "Work in progress. For reference, see: "
-                "https://leap.se/code/issues/7370")
+        self.skipTest("Work in progress. For reference, see: "
+                      "https://leap.se/code/issues/7370")
         length = 100 * (10 ** 6)  # 100 MB
         return self._test_encrypted_sym_sync(doc_size=length, number_of_docs=1)
 

--- a/common/src/leap/soledad/common/tests/test_server.py
+++ b/common/src/leap/soledad/common/tests/test_server.py
@@ -481,8 +481,8 @@ class EncryptedSyncTestCase(
         Test if Soledad can sync very large files.
         """
         self.skipTest(
-            "Work in progress. For reference, see: "
-            "https://leap.se/code/issues/7370")
+                "Work in progress. For reference, see: "
+                "https://leap.se/code/issues/7370")
         length = 100 * (10 ** 6)  # 100 MB
         return self._test_encrypted_sym_sync(doc_size=length, number_of_docs=1)
 


### PR DESCRIPTION
Removed some optimizations and optimized other slow parts instead.
Main changes:
+ multiprocessing -> nothing (inline decrypt seems fast enough, while multiprocessing was consuming large amounts of RAM for no benefit here)
+ Recursive timed calls -> LoopingCall
+ Sequence from fetched decrypted docs -> sequence from in-memory simple set of indexes
+ Single doc delete from staging -> bulk delete
+ tests for start/stop on decrypter pool.
+ tests for incomplete sequences handling.
