### PR TITLE
[feat] debug-mode server with dummy authentication

### DIFF
--- a/server/src/leap/soledad/server/__init__.py
+++ b/server/src/leap/soledad/server/__init__.py
@@ -312,16 +312,34 @@ def load_configuration(file_path):
 # Run as Twisted WSGI Resource
 # ----------------------------------------------------------------------------
 
-def application(environ, start_response):
+
+def _load_config():
     conf = load_configuration('/etc/soledad/soledad-server.conf')
-    conf = conf['soledad-server']
+    return conf['soledad-server']
+
+
+def _get_couch_state():
+    conf = _load_config()
     state = CouchServerState(conf['couch_url'], create_cmd=conf['create_cmd'])
-    SoledadBackend.BATCH_SUPPORT = conf['batching']
-    # WSGI application that may be used by `twistd -web`
+    SoledadBackend.BATCH_SUPPORT = conf.get('batching', False)
+    return state
+
+
+def application(environ, start_response):
+    """return WSGI application that may be used by `twistd -web`"""
+    state = _get_couch_state()
     application = GzipMiddleware(
         SoledadTokenAuthMiddleware(SoledadApp(state)))
-
     return application(environ, start_response)
+
+
+def debug_local_application_do_not_use(environ, start_response):
+    """in where we bypass token auth middleware for ease of mind while
+    debugging in your local environment"""
+    state = _get_couch_state()
+    application = SoledadApp(state)
+    return application(environ, start_response)
+
 
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
to ease debugging of local servers w/o neededing the Token machinery in
place.

this needs still some extra changes to be fully functional:

- solve auth problems in sync locks.
- adapt the create-userdb script to work with no auth info.