### PR TITLE
[bug] initialize OpenSSL context just once

### DIFF
--- a/client/src/leap/soledad/client/crypto.py
+++ b/client/src/leap/soledad/client/crypto.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 
 MAC_KEY_LENGTH = 64
 
+crypto_backend = MultiBackend([OpenSSLBackend()])
+
 
 def encrypt_sym(data, key):
     """
@@ -59,8 +61,7 @@ def encrypt_sym(data, key):
         (len(key) * 8))
 
     iv = os.urandom(16)
-    backend = MultiBackend([OpenSSLBackend()])
-    cipher = Cipher(algorithms.AES(key), modes.CTR(iv), backend=backend)
+    cipher = Cipher(algorithms.AES(key), modes.CTR(iv), backend=crypto_backend)
     encryptor = cipher.encryptor()
     ciphertext = encryptor.update(data) + encryptor.finalize()
 
@@ -87,9 +88,8 @@ def decrypt_sym(data, key, iv):
     soledad_assert(
         len(key) == 32,  # 32 x 8 = 256 bits.
         'Wrong key size: %s (must be 256 bits long).' % len(key))
-    backend = MultiBackend([OpenSSLBackend()])
     iv = binascii.a2b_base64(iv)
-    cipher = Cipher(algorithms.AES(key), modes.CTR(iv), backend=backend)
+    cipher = Cipher(algorithms.AES(key), modes.CTR(iv), backend=crypto_backend)
     decryptor = cipher.decryptor()
     return decryptor.update(data) + decryptor.finalize()
 

--- a/client/src/leap/soledad/client/encdecpool.py
+++ b/client/src/leap/soledad/client/encdecpool.py
@@ -178,9 +178,11 @@ class SyncEncrypterPool(SyncEncryptDecryptPool):
         secret = self._crypto.secret
         args = doc.doc_id, doc.rev, docstr, key, secret
         # encrypt asynchronously
+        # TODO use dedicated threadpool / move to ampoule
         d = threads.deferToThread(
             encrypt_doc_task, *args)
         d.addCallback(self._encrypt_doc_cb)
+        return d
 
     def _encrypt_doc_cb(self, result):
         """
@@ -429,9 +431,12 @@ class SyncDecrypterPool(SyncEncryptDecryptPool):
         secret = self._crypto.secret
         args = doc_id, doc_rev, content, gen, trans_id, key, secret, idx
         # decrypt asynchronously
-        doc = decrypt_doc_task(*args)
+        # TODO use dedicated threadpool / move to ampoule
+        d = threads.deferToThread(
+            decrypt_doc_task, *args)
         # callback will insert it for later processing
-        return self._decrypt_doc_cb(doc)
+        d.addCallback(self._decrypt_doc_cb)
+        return d
 
     def insert_received_doc(
             self, doc_id, doc_rev, content, gen, trans_id, idx):


### PR DESCRIPTION
Do not initialize the openssl context on each call to decrypt.

I'm not 100% sure of the causal chain, but it seems that the
initialization of the osrandom engine that openssl backend does might be
breaking havoc when sqlcipher is calling rand_bytes concurrently.

further testing is needed to confirm this is the ultimate cause, but in
my tests this change avoids the occurrence of the dreaded Floating Point
Exception in soledad/sqlcipher.

- Resolves: #8180