### PR TITLE
[Memory Leak] Removed finalClose from SQLCipherU1DBSync

### DIFF
--- a/client/src/leap/soledad/client/sqlcipher.py
+++ b/client/src/leap/soledad/client/sqlcipher.py
@@ -448,7 +448,6 @@ class SQLCipherU1DBSync(SQLCipherDatabase):
         self.received_docs = []
 
         self.running = False
-        self.shutdownID = None
         self._db_handle = None
 
         # initialize the main db before scheduling a start
@@ -465,8 +464,6 @@ class SQLCipherU1DBSync(SQLCipherDatabase):
 
     def _start(self):
         if not self.running:
-            self.shutdownID = self._reactor.addSystemEventTrigger(
-                'during', 'shutdown', self.finalClose)
             self.running = True
 
     def _initialize_main_db(self):
@@ -561,13 +558,6 @@ class SQLCipherU1DBSync(SQLCipherDatabase):
         # XXX this SHOULD BE a callback
         return self._get_generation()
 
-    def finalClose(self):
-        """
-        This should only be called by the shutdown trigger.
-        """
-        self.shutdownID = None
-        self.running = False
-
     def close(self):
         """
         Close the syncer and syncdb orderly
@@ -578,6 +568,7 @@ class SQLCipherU1DBSync(SQLCipherDatabase):
             _, syncer = self._syncers[url]
             syncer.close()
             del self._syncers[url]
+        self.running = False
 
 
 class U1DBSQLiteBackend(sqlite_backend.SQLitePartialExpandDatabase):


### PR DESCRIPTION
We discovered that class was registering a `finalClose` to be
executed on reactor shutdown.

On the multiuser scenario, a logout destroys Soledad and should
properly terminate everything related to it. That SQLCipherU1DBSync
instance was being held even after logout by the reactor so it
could call that `finalClose` on shutdown.

The `finalClose` only set running to False and set a `shutdownID` that
was not used anywhere else, so we removed it and moved setting
running to False to the `close` function method. That way we preserve
the functionality but let the instance be properly garbage collected
on logout.